### PR TITLE
Running Tests in Shippable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
  language: node_js
  node_js:
    - "0.10"
-before-install: npm install -g grunt-cli
-install: npm install
+before-install:
+  - npm install -g grunt-cli
+install:
+  - npm install
+before_script:
+  - npm install -g bower
+  - bower install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
  language: node_js
  node_js:
    - "0.10"
+before-install: npm install -g grunt-cli
+install: npm install
+before-script: grunt build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
- language: node_js
- node_js:
+language: node_js
+node_js:
    - "0.10"
 before_install:
   - npm install -g grunt-cli

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@
    - "0.10"
 before-install: npm install -g grunt-cli
 install: npm install
-before-script: grunt build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
  language: node_js
  node_js:
    - "0.10"
-before-install:
-  - npm install -g grunt-cli
 install:
   - npm install
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
  language: node_js
  node_js:
    - "0.10"
+before_install:
+  - npm install -g grunt-cli
+  - npm install -g bower
 install:
   - npm install
-before_script:
-  - npm install -g bower
   - bower install
+

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,7 +51,7 @@ module.exports = function (grunt) {
 
             js: {
                 files: '<%= browserify.standalone.src %>',
-                tasks: ['jshint', 'browserify:standalone', 
+                tasks: ['jshint', 'browserify:standalone',
                         'browserify:test', 'casper:acceptance']
             },
 
@@ -84,17 +84,17 @@ module.exports = function (grunt) {
               test : true
             },
             files : {
-              'test/front-end/acceptance/casper-results.xml' : 
+              'test/front-end/acceptance/casper-results.xml' :
                     ['test/front-end/acceptance/main_page_test.js']
             }
           }
         }
 
     });
-    
+
     grunt.registerTask('server', ['jshint', 'express:dev', 'build', 'watch']);
     grunt.registerTask('serve', ['server']);
-    grunt.registerTask('test', ['jshint', 'browserify:test', 'casper:acceptance']);
-    grunt.registerTask('build', ['clean', 'browserify:standalone', 'copy']);
+    grunt.registerTask('test', ['jshint', 'browserify:test', 'express:dev', 'casper:acceptance']);
+    gitrunt.registerTask('build', ['clean', 'browserify:standalone', 'copy']);
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -95,6 +95,6 @@ module.exports = function (grunt) {
     grunt.registerTask('server', ['jshint', 'express:dev', 'build', 'watch']);
     grunt.registerTask('serve', ['server']);
     grunt.registerTask('test', ['jshint', 'browserify:test', 'express:dev', 'casper:acceptance']);
-    gitrunt.registerTask('build', ['clean', 'browserify:standalone', 'copy']);
+    grunt.registerTask('build', ['clean', 'browserify:standalone', 'copy']);
 
 };

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-yelp_a_route
+Flappy Mappy
 ============
 
-App to show user good yelp spots on the way to their destination.
+This is a web application to display Google Places along a route to a user's destination.
 
-[![Build Status](https://travis-ci.org/FlappyMappy/yelp_a_route.svg?branch=master)](https://travis-ci.org/FlappyMappy/yelp_a_route)
+This is a JavaScript app that used Google Map and Google Places APIs. If you're interested in looking at the code, we used Underscore, jQuery, Grunt, Express, Browserify, Casper, Mocha, Chai, jQuery scrollTo by Ariel Flesler.
+
+[![Build Status](https://api.shippable.com/projects/5388c96a5e755afa02b59e45/badge/master)](https://www.shippable.com/projects/5388c96a5e755afa02b59e45/builds/history)

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "mocha": "^1.18.2"
   },
   "scripts": {
+    "postinstall": "bower install",
     "test": "grunt test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "mocha": "^1.18.2"
   },
   "scripts": {
-    "test": "./node_modules/grunt-cli/bin/grunt test"
+    "test": "node_modules/grunt-cli/bin/grunt test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
     "hbsfy": "^1.3.2",
     "matchdep": "^0.3.0",
     "mocha": "^1.18.2"
+  },
+  "scripts": {
+    "test": "grunt test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,6 @@
     "mocha": "^1.18.2"
   },
   "scripts": {
-    "test": "node_modules/grunt-cli/bin/grunt test"
+    "test": "grunt test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "debowerify": "^0.7.1",
     "globule": "^0.2.0",
     "grunt-browserify": "^2.1.0",
+    "grunt-cli": "*",
     "grunt-casper": "^0.3.8",
     "grunt-contrib-clean": "^0.5.0",
     "grunt-contrib-copy": "^0.5.0",
@@ -25,6 +26,6 @@
     "mocha": "^1.18.2"
   },
   "scripts": {
-    "test": "grunt test"
+    "test": "./node_modules/grunt-cli/bin/grunt test"
   }
 }


### PR DESCRIPTION
We were having trouble with getting Travis CI to run grunt-cli. We made a series of edits to travis.yml and package.json and then realized we needed to add express:dev to our grunt test tasks in the Gruntfile.js. We also tried running our build test with Shippable and it executed a lot faster. I added the Shippable badge to the README.md and added an updated app summary.
